### PR TITLE
Use package-relative imports in buildcompiler

### DIFF
--- a/src/buildcompiler/buildcompiler.py
+++ b/src/buildcompiler/buildcompiler.py
@@ -1,9 +1,9 @@
 import sbol2
 from typing import Union, List
 import zipfile
-from abstract_translator import translate_abstract_to_plasmids
-from sbol2build import golden_gate_assembly_plan
-from robotutils import assembly_plan_RDF_to_JSON, run_opentrons_script_with_json_to_zip
+from .abstract_translator import translate_abstract_to_plasmids
+from .sbol2build import golden_gate_assembly_plan
+from .robotutils import assembly_plan_RDF_to_JSON, run_opentrons_script_with_json_to_zip
 
 
 # function which input is an abstract design and  output build specifications by creating an assembly plan, and a zip file with a run_sbol2assembly.py, an automated_assembly_log.txt, assemblyplan_output.JSON, and assembly_protocol.xlsx


### PR DESCRIPTION
### Motivation
- Ensure internal module imports resolve correctly when the package is installed by switching `buildcompiler.py` to package-relative imports.

### Description
- Update `src/buildcompiler/buildcompiler.py` to use `from .abstract_translator import translate_abstract_to_plasmids`, `from .sbol2build import golden_gate_assembly_plan`, and `from .robotutils import assembly_plan_RDF_to_JSON, run_opentrons_script_with_json_to_zip` so internal imports are package-scoped.

### Testing
- Ran `python -m pytest`, which executed the test suite but ended with `4 failed, 5 passed, 3 errors` due to network/proxy failures contacting external SBOL services; ran `ruff check .`, which reported many existing lint issues across notebooks and scripts (these are preexisting and not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7422919c83309da145430d950c5c)