### PR TITLE
Add output_path option to assembly_plan_RDF_to_JSON and update build compiler

### DIFF
--- a/src/buildcompiler/buildcompiler.py
+++ b/src/buildcompiler/buildcompiler.py
@@ -1,5 +1,5 @@
 import sbol2
-from typing import Union, List
+from typing import Union
 import zipfile
 from .abstract_translator import translate_abstract_to_plasmids
 from .sbol2build import golden_gate_assembly_plan
@@ -38,7 +38,10 @@ def assembly_compiler(abstract_design: Union[sbol2.Component, sbol2.Combinatoria
                                               document= document)
     
     # Generate build specifications JSON
-    build_specs_JSON = assembly_plan_RDF_to_JSON(assembly_plan)
+    assembly_plan_RDF_to_JSON(
+        assembly_plan,
+        output_path=f"{files_path}/assemblyplan_output.json",
+    )
     
     # Create zip file with required files
     zip_file = run_opentrons_script_with_json_to_zip(opentrons_script_path= files_path + "/run_sbol2assembly_libre.py",

--- a/src/buildcompiler/robotutils.py
+++ b/src/buildcompiler/robotutils.py
@@ -7,8 +7,8 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-def assembly_plan_RDF_to_JSON(file):
-    if type(file)==sbol2.Document:
+def assembly_plan_RDF_to_JSON(file, output_path: str | Path | None = None):
+    if isinstance(file, sbol2.Document):
         doc = file
     else:
         sbol2.Config.setOption('sbol_typed_uris', False)
@@ -77,7 +77,8 @@ def assembly_plan_RDF_to_JSON(file):
     for entry in product_dicts:
         entry['Restriction Enzyme'] = globalEnzyme
 
-    with open('output.json', 'w') as json_file:
+    json_output_path = Path(output_path) if output_path is not None else Path("output.json")
+    with json_output_path.open('w', encoding='utf-8') as json_file:
         json.dump(product_dicts, json_file, indent=4)
 
     return product_dicts

--- a/src/sbol2build/robotutils.py
+++ b/src/sbol2build/robotutils.py
@@ -2,7 +2,7 @@ import sbol2
 import json
 
 def assembly_plan_RDF_to_JSON(file):
-    if type(file)==sbol2.Document:
+    if isinstance(file, sbol2.Document):
         doc = file
     else:
         sbol2.Config.setOption('sbol_typed_uris', False)


### PR DESCRIPTION
### Motivation
- Allow callers to control where the assembly-plan JSON is written so downstream steps (zip/simulation) can rely on a known file location instead of a hardcoded `output.json`.

### Description
- Add an optional `output_path: str | Path | None` parameter to `assembly_plan_RDF_to_JSON` and write JSON to the provided path, defaulting to `output.json` when omitted (`src/buildcompiler/robotutils.py`).
- Update `assembly_compiler` to call `assembly_plan_RDF_to_JSON(..., output_path=f"{files_path}/assemblyplan_output.json")` so the zip step uses the generated file (`src/buildcompiler/buildcompiler.py`).
- Normalize SBOL type checks to use `isinstance(file, sbol2.Document)` in both robotutils modules and tidy up a now-unused import/assignment in the build compiler.

### Testing
- Ran `pytest`, which executed the test suite but produced network-related failures/errors against external services (proxy blocked access to synbiohub.org / validator.sbolstandard.org), so several tests failed or errored; this is due to external network validation calls, not the JSON output change.
- Ran `ruff check src`, which passed with no remaining lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a790caf6483309ec4ec8b77667d5f)