### PR TITLE
Run opentrons_simulate inside tempdir and use temp-copied inputs

### DIFF
--- a/src/buildcompiler/robotutils.py
+++ b/src/buildcompiler/robotutils.py
@@ -1,6 +1,5 @@
 import sbol2
 import json
-import os
 import shutil
 import subprocess
 import tempfile
@@ -131,11 +130,15 @@ def run_opentrons_script_with_json_to_zip(
 
         # Run inside temp dir so relative-path outputs land in tmpdir (and get zipped)
 
-            # Run script (which has opentrons script hardcoded) using JSON file
-        log = subprocess.run(["opentrons_simulate", opentrons_script_path, json_file_path], capture_output=True).stdout
+        # Run script (which has opentrons script hardcoded) using JSON file
+        log = subprocess.run(
+            ["opentrons_simulate", str(tmp_script), str(tmp_json)],
+            capture_output=True,
+            cwd=tmpdir,
+        ).stdout
         
         # Save log to a file in the temporary directory
-        with open(os.path.join(tmpdir, "build_log.txt"), "wb") as log_file: 
+        with open(tmpdir / "build_log.txt", "wb") as log_file: 
             log_file.write(log)
 
         # Always include logs in the zip


### PR DESCRIPTION
### Motivation
- Ensure any files created by the Opentrons simulator land inside the temporary staging folder so they are included in the produced ZIP archive.
- Simplify log writing into the temp folder and remove an unused `os` import.

### Description
- In `run_opentrons_script_with_json_to_zip` copy the script and JSON into the temporary directory and call `subprocess.run` with the temp paths and `cwd=tmpdir` using `[
  "opentrons_simulate", str(tmp_script), str(tmp_json)
]`, so the simulator runs inside the temp folder.
- Save the captured stdout into `tmpdir / "build_log.txt"` using `Path` APIs instead of `os.path`.
- Remove the now-unused `import os` from `src/buildcompiler/robotutils.py`.

### Testing
- Ran `python -m pytest`, which exercised the test suite but completed with failures unrelated to this change: 4 failing tests and 3 errors caused by external network/proxy errors when `sbol2` attempted validation against remote endpoints (e.g. `validator.sbolstandard.org`).
- Ran `ruff check .`, which reported many pre-existing lint issues across notebooks and other files; the change removed a single unused import but the overall lint run did not pass.
- Conclusion: the change to run the simulator in the temp directory and write the log succeeded locally in code, but automated test runs were impeded by external network and preexisting linter problems, not by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7fe584c483309ea55c083a486f5a)