### PR TITLE
Add clean-architecture package scaffolding (issue #53)

### DIFF
--- a/src/buildcompiler/adapters/__init__.py
+++ b/src/buildcompiler/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/adapters/opentrons/__init__.py
+++ b/src/buildcompiler/adapters/opentrons/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/adapters/pudu/__init__.py
+++ b/src/buildcompiler/adapters/pudu/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/api/__init__.py
+++ b/src/buildcompiler/api/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/domain/__init__.py
+++ b/src/buildcompiler/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/execution/__init__.py
+++ b/src/buildcompiler/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/inventory/__init__.py
+++ b/src/buildcompiler/inventory/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/planning/__init__.py
+++ b/src/buildcompiler/planning/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/reporting/__init__.py
+++ b/src/buildcompiler/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/sbol/__init__.py
+++ b/src/buildcompiler/sbol/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/src/buildcompiler/stages/__init__.py
+++ b/src/buildcompiler/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffolding for clean architecture."""

--- a/tests/test_package_scaffolding.py
+++ b/tests/test_package_scaffolding.py
@@ -1,0 +1,15 @@
+"""Import smoke tests for clean-architecture package scaffolding."""
+
+
+def test_clean_architecture_package_imports() -> None:
+    import buildcompiler.api  # noqa: F401
+    import buildcompiler.domain  # noqa: F401
+    import buildcompiler.planning  # noqa: F401
+    import buildcompiler.execution  # noqa: F401
+    import buildcompiler.stages  # noqa: F401
+    import buildcompiler.sbol  # noqa: F401
+    import buildcompiler.inventory  # noqa: F401
+    import buildcompiler.adapters  # noqa: F401
+    import buildcompiler.adapters.pudu  # noqa: F401
+    import buildcompiler.adapters.opentrons  # noqa: F401
+    import buildcompiler.reporting  # noqa: F401


### PR DESCRIPTION
### Motivation

- Provide the package structure required by the clean-architecture rewrite (ADR-001 / ARCHITECTURE.md) so future milestones can implement domain contracts, planners, stages, execution, adapters, and reporting without changing the root package name `buildcompiler`.
- Keep the change strictly scaffolding-only: no behavior, no compatibility wrappers, and no optional automation dependencies imported from core packages.

### Description

- Added package markers (`__init__.py`) for the new clean-architecture layout: `api`, `domain`, `planning`, `execution`, `stages`, `sbol`, `inventory`, `adapters`, `adapters.pudu`, `adapters.opentrons`, and `reporting` under `src/buildcompiler/`.
- Added a small import smoke test `tests/test_package_scaffolding.py` that imports each new package to validate that core imports resolve without pulling optional automation dependencies.
- All new `__init__.py` files are minimal placeholders (module docstrings only) to avoid introducing behavior or external dependencies.

### Testing

- Ran `PYTHONPATH=src python -c "import buildcompiler"` and `PYTHONPATH=src python -c "import buildcompiler.api; import buildcompiler.domain; import buildcompiler.planning; import buildcompiler.execution; import buildcompiler.stages; import buildcompiler.sbol; import buildcompiler.inventory; import buildcompiler.adapters; import buildcompiler.adapters.pudu; import buildcompiler.adapters.opentrons; import buildcompiler.reporting"`, both of which succeeded (imports resolved from `src`).
- Ran `PYTHONPATH=src pytest tests/test_package_scaffolding.py` and the single import-smoke test passed (`1 passed`).
- Attempted `uv run ruff check .` but the run failed during environment preparation due to a network/git fetch error for an optional dependency (`SBOLInventory`), so `uv`-based linting could not complete in this environment; running `ruff check .` without `uv` was attempted but revealed pre-existing lint issues outside the scope of this scaffolding PR.
- Assumptions and follow-up: local import validation with `PYTHONPATH=src` is acceptable for this scaffolding step; next work items are issue #54 (domain enums/dataclasses) followed by #55 (BuildOptions) and no behavioral work is included here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9feddaaa88323802f033be2035d0d)