### PR TITLE
[ISSUE-03] Implement BuildOptions option groups

### DIFF
--- a/src/buildcompiler/api/__init__.py
+++ b/src/buildcompiler/api/__init__.py
@@ -1,1 +1,31 @@
-"""Package scaffolding for clean architecture."""
+"""Public API contracts and options for BuildCompiler."""
+
+from .options import (
+    ApprovalOptions,
+    BuildOptions,
+    CombinatorialOptions,
+    DomesticationOptions,
+    ExecutionOptions,
+    Lvl2SearchOptions,
+    PlanningOptions,
+    ProtocolMode,
+    ProtocolOptions,
+    ReagentOptions,
+    ReportingOptions,
+    SelectionOptions,
+)
+
+__all__ = [
+    "ApprovalOptions",
+    "BuildOptions",
+    "CombinatorialOptions",
+    "DomesticationOptions",
+    "ExecutionOptions",
+    "Lvl2SearchOptions",
+    "PlanningOptions",
+    "ProtocolMode",
+    "ProtocolOptions",
+    "ReagentOptions",
+    "ReportingOptions",
+    "SelectionOptions",
+]

--- a/src/buildcompiler/api/options.py
+++ b/src/buildcompiler/api/options.py
@@ -1,0 +1,89 @@
+"""Build options contracts for full_build configuration."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+
+class ProtocolMode(str, Enum):
+    """Protocol generation mode."""
+
+    NONE = "none"
+    MANUAL = "manual"
+    AUTOMATED = "automated"
+
+
+@dataclass
+class CombinatorialOptions:
+    max_variants: int = 256
+    allow_large_expansion: bool = False
+
+
+@dataclass
+class Lvl2SearchOptions:
+    max_exhaustive_region_count: int = 4
+    allow_large_order_search: bool = False
+
+
+@dataclass
+class PlanningOptions:
+    combinatorial: CombinatorialOptions = field(default_factory=CombinatorialOptions)
+    lvl2_search: Lvl2SearchOptions = field(default_factory=Lvl2SearchOptions)
+
+
+@dataclass
+class ExecutionOptions:
+    max_iterations: int = 5
+    continue_on_error: bool = False
+
+
+@dataclass
+class SelectionOptions:
+    prefer_existing_collection_material: bool = True
+    prefer_higher_material_state: bool = True
+
+
+@dataclass
+class ProtocolOptions:
+    mode: ProtocolMode = ProtocolMode.NONE
+    simulate: bool = False
+    results_dir: str | Path | None = None
+
+
+@dataclass
+class ReportingOptions:
+    include_detailed_report: bool = False
+    include_rejected_routes: bool = True
+    max_rejected_routes: int = 3
+
+
+@dataclass
+class ApprovalOptions:
+    approved_processes: set[str] = field(default_factory=set)
+    approved_approval_ids: set[str] = field(default_factory=set)
+    scope: Literal["run", "persistent"] = "run"
+
+
+@dataclass
+class ReagentOptions:
+    allow_reagent_purchase: bool = False
+    default_restriction_enzyme: str = "BsaI"
+    default_ligase: str = "T4_DNA_ligase"
+
+
+@dataclass
+class DomesticationOptions:
+    allow_sequence_domestication_edits: bool = False
+
+
+@dataclass
+class BuildOptions:
+    planning: PlanningOptions = field(default_factory=PlanningOptions)
+    execution: ExecutionOptions = field(default_factory=ExecutionOptions)
+    selection: SelectionOptions = field(default_factory=SelectionOptions)
+    protocol: ProtocolOptions = field(default_factory=ProtocolOptions)
+    reporting: ReportingOptions = field(default_factory=ReportingOptions)
+    approvals: ApprovalOptions = field(default_factory=ApprovalOptions)
+    reagents: ReagentOptions = field(default_factory=ReagentOptions)
+    domestication: DomesticationOptions = field(default_factory=DomesticationOptions)

--- a/tests/unit/api/test_options.py
+++ b/tests/unit/api/test_options.py
@@ -1,0 +1,37 @@
+from buildcompiler.api import BuildOptions, ProtocolMode
+
+
+def test_build_options_defaults_match_contract():
+    options = BuildOptions()
+
+    assert options.execution.max_iterations == 5
+    assert options.execution.continue_on_error is False
+    assert options.protocol.mode == ProtocolMode.NONE
+    assert options.protocol.simulate is False
+    assert options.reagents.allow_reagent_purchase is False
+    assert options.reagents.default_restriction_enzyme == "BsaI"
+    assert options.reagents.default_ligase == "T4_DNA_ligase"
+    assert options.domestication.allow_sequence_domestication_edits is False
+    assert options.planning.combinatorial.max_variants == 256
+    assert options.planning.combinatorial.allow_large_expansion is False
+    assert options.planning.lvl2_search.max_exhaustive_region_count == 4
+    assert options.planning.lvl2_search.allow_large_order_search is False
+    assert options.reporting.include_rejected_routes is True
+    assert options.reporting.max_rejected_routes == 3
+    assert options.approvals.approved_processes == set()
+    assert options.approvals.approved_approval_ids == set()
+
+
+def test_mutable_defaults_are_isolated_across_instances():
+    left = BuildOptions()
+    right = BuildOptions()
+
+    left.approvals.approved_processes.add("biosafety")
+    left.approvals.approved_approval_ids.add("approval-1")
+    left.planning.combinatorial.max_variants = 1024
+    left.reporting.max_rejected_routes = 10
+
+    assert right.approvals.approved_processes == set()
+    assert right.approvals.approved_approval_ids == set()
+    assert right.planning.combinatorial.max_variants == 256
+    assert right.reporting.max_rejected_routes == 3


### PR DESCRIPTION
### Motivation
- Provide a focused, safe configuration/contract layer for the `full_build` clean-architecture refactor so later planner, executor, stage, inventory, adapter, and reporting components can consume typed option groups.
- Keep defaults conservative and compiler-only, avoid pulling optional automation dependencies, and ensure mutable defaults are isolated across instances.

### Description
- Added `src/buildcompiler/api/options.py` implementing `ProtocolMode` and composed option dataclasses: `CombinatorialOptions`, `Lvl2SearchOptions`, `PlanningOptions`, `ExecutionOptions`, `SelectionOptions`, `ProtocolOptions`, `ReportingOptions`, `ApprovalOptions`, `ReagentOptions`, `DomesticationOptions`, and `BuildOptions`, using `field(default_factory=...)` for nested/mutable defaults.
- Updated `src/buildcompiler/api/__init__.py` to export `BuildOptions`, the focused option-group dataclasses, and `ProtocolMode` for lightweight imports.
- Added unit tests `tests/unit/api/test_options.py` that validate required defaults and mutable-default isolation across `BuildOptions` instances.
- Reused existing domain approval enum (`ApprovalStatus`) in domain contracts and avoided importing or requiring optional automation packages in core option modules.

### Testing
- Ran import smoke checks with `PYTHONPATH=src python -c "from buildcompiler.api.options import BuildOptions; BuildOptions()"` and `PYTHONPATH=src python -c "from buildcompiler.api import BuildOptions; BuildOptions()"`, both of which succeeded.
- Ran unit tests with `PYTHONPATH=src pytest tests/unit/api/test_options.py`, which passed (`2 passed`), and broader package tests with `PYTHONPATH=src pytest tests/unit/domain tests/unit/api`, which also passed (`5 passed`).
- Attempting `uv run pytest tests/unit/api/test_options.py` failed here due to environment resolution of an optional `SBOLInventory` dependency (git fetch returned HTTP 403), so `uv`-based verification could not complete in this environment.
- Ran lint/format checks `ruff check .` and `ruff format --check .` which reported pre-existing repository issues unrelated to these changes (these lint/format failures are outside the scope of this PR).

Closes #55 
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa1d67b62083238126fdcc5adb4851)