### PR TITLE
Fallback when `region_order` is unsatisfiable for lvl2 assembly and add warning

### DIFF
--- a/src/buildcompiler/stages/assembly_lvl2.py
+++ b/src/buildcompiler/stages/assembly_lvl2.py
@@ -74,6 +74,22 @@ class AssemblyLvl2Stage:
             region_identities=region_identities,
             constraints=constraints,
         )
+        warning_logs: list[str] = []
+        if route_selection.selected is None and constraints.get("region_order"):
+            relaxed_constraints = {
+                key: value for key, value in constraints.items() if key != "region_order"
+            }
+            relaxed_selection = self.selector.select_lvl2_route(
+                request_id=request.id,
+                region_identities=region_identities,
+                constraints=relaxed_constraints,
+            )
+            if relaxed_selection.selected is not None:
+                route_selection = relaxed_selection
+                warning_logs.append(
+                    "Unable to satisfy region_order constraint; proceeding with an arbitrary compatible order."
+                )
+
         route = route_selection.selected
         artifacts = self._route_artifacts(route, route_selection.rejected)
         if route is None:
@@ -85,7 +101,8 @@ class AssemblyLvl2Stage:
                 protocol_artifacts=artifacts,
                 logs=[
                     "No lvl2 route selected by CompatibilitySelector. Provide explicit region_order "
-                    "or enable large-order search for large designs."
+                    "or enable large-order search for large designs.",
+                    *warning_logs,
                 ],
             )
 
@@ -157,7 +174,8 @@ class AssemblyLvl2Stage:
                 missing_inputs=missing_inputs,
                 protocol_artifacts=artifacts,
                 logs=[
-                    f"Blocked lvl2 assembly for {request.id}; missing {len(missing_inputs)} required input(s)."
+                    *warning_logs,
+                    f"Blocked lvl2 assembly for {request.id}; missing {len(missing_inputs)} required input(s).",
                 ],
             )
 
@@ -208,6 +226,7 @@ class AssemblyLvl2Stage:
             json_intermediate=json_intermediate,
             protocol_artifacts=artifacts,
             logs=[
+                *warning_logs,
                 f"Selected lvl2 route with {len(route.selected_lvl1_plasmids)} lvl1 plasmid(s).",
                 *assembly_result.logs,
             ],
@@ -216,9 +235,6 @@ class AssemblyLvl2Stage:
     def _extract_region_identities(
         self, module_definition: sbol2.ModuleDefinition, constraints: Mapping[str, Any]
     ) -> list[str]:
-        constrained = constraints.get("region_order")
-        if constrained:
-            return list(constrained)
         for key in ("engineered_region_identities", "region_identities"):
             values = constraints.get(key)
             if values:

--- a/tests/unit/stages/test_assembly_lvl2.py
+++ b/tests/unit/stages/test_assembly_lvl2.py
@@ -189,3 +189,20 @@ def test_assembly_lvl2_region_order_constraint_is_hard():
 
     assert result.status == StageStatus.SUCCESS
     assert result.protocol_artifacts["selected_route"]["region_order"] == order
+
+
+def test_assembly_lvl2_incomplete_region_order_falls_back_with_warning():
+    doc, module, regions = _module_doc()
+    inv = _inventory(regions)
+    stage = AssemblyLvl2Stage(inventory=inv, assembly_service=_FakeAssemblyService([]))
+
+    incomplete_order = [regions[0]]
+    result = stage.run(
+        _request(module.identity, constraints={"region_order": incomplete_order}),
+        source_document=doc,
+        target_document=sbol2.Document(),
+    )
+
+    assert result.status == StageStatus.SUCCESS
+    assert result.protocol_artifacts["selected_route"] is not None
+    assert any("Unable to satisfy region_order constraint" in log for log in result.logs)


### PR DESCRIPTION
### Motivation

- Make lvl2 assembly more robust when a provided `region_order` constraint cannot be satisfied by trying a relaxed search and continuing if a compatible route exists.

### Description

- If `CompatibilitySelector` returns no route due to `region_order`, attempt a second selection without the `region_order` constraint and proceed if that returns a route, collecting a warning in `warning_logs` when this fallback is used.
- Include `warning_logs` in the returned `StageResult` logs for blocked, missing-input, and success outcomes so the user is informed of the relaxed ordering decision.
- Stop treating `region_order` specially in `_extract_region_identities` so region identities are discovered from constraints or the module definition consistently.
- Add unit test `test_assembly_lvl2_incomplete_region_order_falls_back_with_warning` to verify the fallback occurs and a warning is emitted.

### Testing

- Ran the lvl2 assembly unit tests in `tests/unit/stages/test_assembly_lvl2.py` including the new `test_assembly_lvl2_incomplete_region_order_falls_back_with_warning` test, and they all passed.
- The new test asserts that the stage succeeds, a route is selected, and a warning containing "Unable to satisfy region_order constraint" appears in the logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fadb0ea6b8832388d84f10518c47f7)