### PR TITLE
[SPRINT-02-02] Split collection pulling from SBOL document indexing

### DIFF
--- a/src/buildcompiler/buildcompiler.py
+++ b/src/buildcompiler/buildcompiler.py
@@ -42,7 +42,6 @@ from .constants import (
     ENGINEERED_PLASMID,
     PLASMID_CLONING_VECTOR,
     ORGANISM_STRAIN,
-    PLATING_ACTIVITY_ROLE,
 )
 
 
@@ -103,22 +102,24 @@ class BuildCompiler:
         self._merge_document(collection_doc)
         self._index_document_objects(collection_doc)
 
-    def _index_collections(self, collections: List[str]):
-        """Index input collections into plasmids and backbones.
-
-        Parses the provided collections (which may contain plasmids, backbones, strains, and enzymes)
-        and normalizes them into internal Plasmid/enzyme records that remain linked to
-        their originating strain and implementation definitions.
-
-        :param collections: Iterable of user-provided collections/documents.
-        :type collections: Iterable
-        :returns: None. Updates ``self.indexed_plasmids`` in place.
-        :rtype: None
-        """
-        for uri in collections:
+    def pull_collection_uris(self, uris: list[str]) -> sbol2.Document:
+        """Pull SynBioHub collection URIs into ``self.sbol_doc``."""
+        for uri in uris:
             print(f"Indexing collection: {uri}")
-            self.sbh.pull(uri, self.sbol_doc)
-        self._index_current_document()
+            try:
+                self.sbh.pull(uri, self.sbol_doc)
+            except Exception as exc:
+                raise RuntimeError(f"Failed to pull collection URI: {uri}") from exc
+        return self.sbol_doc
+
+    def index_sbol_document(self, doc: sbol2.Document, source: str = "local"):
+        """Index plasmids, backbones, and reagents from an SBOL document."""
+        self._index_document_objects(doc, source=source)
+
+    def _index_collections(self, collections: List[str]):
+        """Compatibility wrapper for URI pull + indexing."""
+        doc = self.pull_collection_uris(collections)
+        self.index_sbol_document(doc, source="synbiohub")
 
     def _merge_document(self, source_doc: sbol2.Document):
         try:
@@ -144,70 +145,77 @@ class BuildCompiler:
         return get_or_pull(self.sbol_doc, self.sbh, uri)
 
     def _index_current_document(self):
-        self._index_document_objects(self.sbol_doc)
+        self._index_document_objects(self.sbol_doc, source="current")
 
     def _append_implementation_once(self, implementations: list, implementation):
         if not any(existing.identity == implementation.identity for existing in implementations):
             implementations.append(implementation)
 
-    def _index_document_objects(self, source_doc: sbol2.Document):
+    def _index_document_objects(self, source_doc: sbol2.Document, source: str = "local"):
         for implementation in source_doc.implementations:
-            built_object = self._resolve_object(implementation.built)
-            if (
-                type(built_object) is sbol2.ModuleDefinition
-                and ORGANISM_STRAIN in built_object.roles
-            ):
-                self._extract_plasmids_from_strain(
-                    built_object, implementation, self.sbol_doc
-                )
-            elif (
-                type(built_object) is sbol2.ComponentDefinition
-                and len(built_object.components) > 1
-            ):
-                if ENGINEERED_PLASMID in built_object.roles:
-                    existing_plasmid = self._get_indexed_plasmid(
-                        self.indexed_plasmids, built_object
-                    )
-                    if existing_plasmid:
-                        self._append_implementation_once(
-                            existing_plasmid.plasmid_implementations, implementation
-                        )
-                    else:
-                        self.indexed_plasmids.append(
-                            Plasmid(
-                                built_object, None, [implementation], [], self.sbol_doc
-                            )
-                        )
-                elif PLASMID_CLONING_VECTOR in built_object.roles:
-                    existing_backbone = self._get_indexed_plasmid(
-                        self.indexed_backbones, built_object
-                    )
-                    if existing_backbone:
-                        self._append_implementation_once(
-                            existing_backbone.plasmid_implementations, implementation
-                        )
-                    else:
-                        self.indexed_backbones.append(
-                            Plasmid(
-                                built_object, None, [implementation], [], self.sbol_doc
-                            )
-                        )
-            elif sbol2.BIOPAX_PROTEIN in built_object.types:
-                if RESTRICTION_ENZYME in built_object.roles:
-                    self._append_implementation_once(
-                        self.restriction_enzyme_implementations, implementation
-                    )
-                elif LIGASE in built_object.roles:
-                    self._append_implementation_once(
-                        self.ligase_implementations, implementation
-                    )
+            self._index_implementation(implementation)
 
         for strain in source_doc.moduleDefinitions:
-            if ORGANISM_STRAIN in strain.roles:
-                self._extract_plasmids_from_strain(strain, None, self.sbol_doc)
+            self._index_strain_module(strain, implementation=None)
 
-        for definition in source_doc.componentDefinitions:
-            self._sort_plasmid_components(definition, self.sbol_doc)
+        for definition in self.sbol_doc.componentDefinitions:
+            self._index_plasmid_or_backbone_definition(definition, implementation=None)
+
+    def _index_implementation(self, implementation: sbol2.Implementation):
+        built_object = self._resolve_object(implementation.built)
+        if type(built_object) is sbol2.ModuleDefinition:
+            self._index_strain_module(built_object, implementation=implementation)
+        elif type(built_object) is sbol2.ComponentDefinition:
+            self._index_plasmid_or_backbone_definition(
+                built_object, implementation=implementation
+            )
+            self._index_reagent_implementation(implementation, built_object)
+
+    def _index_strain_module(
+        self, strain: sbol2.ModuleDefinition, implementation: sbol2.Implementation | None
+    ):
+        if ORGANISM_STRAIN in strain.roles:
+            self._extract_plasmids_from_strain(strain, implementation, self.sbol_doc)
+
+    def _index_plasmid_or_backbone_definition(
+        self, definition: sbol2.ComponentDefinition, implementation: sbol2.Implementation | None
+    ):
+        if implementation is not None and len(definition.components) > 1:
+            if ENGINEERED_PLASMID in definition.roles:
+                existing_plasmid = self._get_indexed_plasmid(self.indexed_plasmids, definition)
+                if existing_plasmid:
+                    self._append_implementation_once(
+                        existing_plasmid.plasmid_implementations, implementation
+                    )
+                else:
+                    self.indexed_plasmids.append(
+                        Plasmid(definition, None, [implementation], [], self.sbol_doc)
+                    )
+            elif PLASMID_CLONING_VECTOR in definition.roles:
+                existing_backbone = self._get_indexed_plasmid(
+                    self.indexed_backbones, definition
+                )
+                if existing_backbone:
+                    self._append_implementation_once(
+                        existing_backbone.plasmid_implementations, implementation
+                    )
+                else:
+                    self.indexed_backbones.append(
+                        Plasmid(definition, None, [implementation], [], self.sbol_doc)
+                    )
+
+        self._sort_plasmid_components(definition, self.sbol_doc)
+
+    def _index_reagent_implementation(
+        self, implementation: sbol2.Implementation, built_object: sbol2.ComponentDefinition
+    ):
+        if sbol2.BIOPAX_PROTEIN in built_object.types:
+            if RESTRICTION_ENZYME in built_object.roles:
+                self._append_implementation_once(
+                    self.restriction_enzyme_implementations, implementation
+                )
+            elif LIGASE in built_object.roles:
+                self._append_implementation_once(self.ligase_implementations, implementation)
 
     def domestication(
         self,
@@ -833,7 +841,7 @@ class BuildCompiler:
         ]
 
     def _get_abstract_design(self) -> sbol2.ComponentDefinition:
-        for definition in source_doc.componentDefinitions:
+        for definition in self.sbol_doc.componentDefinitions:
             if (
                 ENGINEERED_PLASMID in definition.roles
                 or PLASMID_CLONING_VECTOR in definition.roles

--- a/tests/test_buildcompiler.py
+++ b/tests/test_buildcompiler.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import sbol2
 
@@ -77,6 +77,74 @@ class TestBuildCompilerLocalIndexing(unittest.TestCase):
             BuildCompiler.from_local_documents([doc])
 
         self.assertIn('Local mode does not pull from SynBioHub', str(ctx.exception))
+
+
+
+
+class TestBuildCompilerCollectionIndexing(unittest.TestCase):
+    def _make_compiler_without_init(self):
+        compiler = BuildCompiler.__new__(BuildCompiler)
+        compiler.sbh = MagicMock()
+        compiler.sbol_doc = sbol2.Document()
+        compiler.indexed_plasmids = []
+        compiler.indexed_backbones = []
+        compiler.restriction_enzyme_implementations = []
+        compiler.ligase_implementations = []
+        return compiler
+
+    def test_index_sbol_document_local_does_not_pull(self):
+        compiler = self._make_compiler_without_init()
+
+        enzyme = sbol2.ComponentDefinition('BsaI_local')
+        enzyme.types = [sbol2.BIOPAX_PROTEIN]
+        enzyme.roles = [RESTRICTION_ENZYME]
+        compiler.sbol_doc.add(enzyme)
+        implementation = sbol2.Implementation('BsaI_local_impl')
+        implementation.built = enzyme.identity
+        compiler.sbol_doc.add(implementation)
+
+        compiler.index_sbol_document(compiler.sbol_doc, source='local')
+
+        compiler.sbh.pull.assert_not_called()
+        self.assertEqual(len(compiler.restriction_enzyme_implementations), 1)
+
+    def test_index_collections_pulls_then_indexes(self):
+        compiler = self._make_compiler_without_init()
+        call_order = []
+
+        def fake_pull(uris):
+            call_order.append('pull')
+            return compiler.sbol_doc
+
+        def fake_index(doc, source='local'):
+            call_order.append(f'index:{source}')
+
+        compiler.pull_collection_uris = fake_pull
+        compiler.index_sbol_document = fake_index
+
+        compiler._index_collections(['https://example.org/collection'])
+
+        self.assertEqual(call_order, ['pull', 'index:synbiohub'])
+
+    def test_pull_failure_has_uri_context(self):
+        compiler = self._make_compiler_without_init()
+        compiler.sbh.pull.side_effect = ValueError('network timeout')
+
+        with self.assertRaises(RuntimeError) as ctx:
+            compiler.pull_collection_uris(['https://example.org/fail'])
+
+        self.assertIn('Failed to pull collection URI: https://example.org/fail', str(ctx.exception))
+
+    def test_indexing_failure_is_distinct_from_pull_failure(self):
+        compiler = self._make_compiler_without_init()
+        bad_doc = sbol2.Document()
+        bad_impl = sbol2.Implementation('impl_missing_built')
+        bad_doc.add(bad_impl)
+
+        with self.assertRaises(Exception) as ctx:
+            compiler.index_sbol_document(bad_doc, source='local')
+
+        self.assertNotIn('Failed to pull collection URI', str(ctx.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Decouple SynBioHub network fetching from SBOL document indexing to make collection indexing reusable for local `sbol2.Document` objects and easier to test and debug. 
- Preserve existing constructor behavior that accepts SynBioHub URIs while avoiding hidden network pulls when indexing local documents. 
- Improve separation of concerns to make indexing helpers individually testable and to clarify failure modes (fetch vs indexing).

### Description
- Added `pull_collection_uris(self, uris: list[str]) -> sbol2.Document` to perform SynBioHub `pull` operations and raise a `RuntimeError` with URI context on fetch failure. (changed file: `src/buildcompiler/buildcompiler.py`).
- Added `index_sbol_document(self, doc: sbol2.Document, source: str = "local")` to perform SBOL scanning/classification without invoking `sbh.pull`, and changed `_index_collections` into a compatibility wrapper that calls `pull_collection_uris` then `index_sbol_document`. (changed file: `src/buildcompiler/buildcompiler.py`).
- Extracted smaller indexing helpers `_index_implementation`, `_index_strain_module`, `_index_plasmid_or_backbone_definition`, and `_index_reagent_implementation` and updated `_index_document_objects` signature to accept a `source` parameter; preserved existing list-based runtime state (`indexed_plasmids`, `indexed_backbones`, `restriction_enzyme_implementations`, `ligase_implementations`). (changed file: `src/buildcompiler/buildcompiler.py`).
- Fixed an undefined-variable bug in `_get_abstract_design` by iterating `self.sbol_doc.componentDefinitions`.
- Added targeted unit tests that exercise local-document indexing and the pull-then-index compatibility behavior. (changed file: `tests/test_buildcompiler.py`).

### Testing
- Ran `pytest -k "index or collection or synbiohub"` and observed all selected tests passed: `16 passed, 107 deselected`.
- Ran `ruff check src/buildcompiler/buildcompiler.py tests/test_buildcompiler.py` and the checks passed for the modified files.
- Attempted the broader integration command `uv run python -m unittest discover -s tests`, which failed in this environment due to an external git dependency fetch error for `SBOLInventory` (HTTP 403), so full test discovery could not complete here.
- Verified that local document indexing path does not call `sbh.pull` and that pull failures surface with URI context while indexing failures remain distinct via the new unit tests (`tests/test_buildcompiler.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b32c5b5d883239f5fc5a9c637ba8d)