### PR TITLE
Format Pudu transformation JSON test

### DIFF
--- a/tests/unit/adapters/pudu/test_transformation_json.py
+++ b/tests/unit/adapters/pudu/test_transformation_json.py
@@ -50,7 +50,9 @@ def test_plasmid_locations_to_pudu_json_uses_deterministic_wells():
 
 
 def test_plasmid_locations_to_pudu_json_accepts_explicit_wells_and_duplicates():
-    payload = plasmid_locations_to_pudu_json(["p1", "p1", "p2"], wells=["A1", "B1", "C1"])
+    payload = plasmid_locations_to_pudu_json(
+        ["p1", "p1", "p2"], wells=["A1", "B1", "C1"]
+    )
 
     assert payload == {
         "p1": ["A1", "B1"],


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `ruff format --check` flagged a formatting issue in a unit test file causing the GitHub CI job to fail.

### Description
- Reformat the `plasmid_locations_to_pudu_json(...)` call in `tests/unit/adapters/pudu/test_transformation_json.py` to a multi-line call so it conforms to Ruff formatting rules.

### Testing
- Ran `ruff format --check src/buildcompiler/api src/buildcompiler/planning src/buildcompiler/execution src/buildcompiler/stages src/buildcompiler/sbol src/buildcompiler/inventory src/buildcompiler/adapters src/buildcompiler/reporting src/buildcompiler/domain tests/conftest.py tests/unit tests/stages tests/integration` which now passes, and ran `pytest tests/unit/adapters/pudu/test_transformation_json.py` which passed (4 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a530b40769c8323be44b7e564dd0ea2)