### PR TITLE
ci: stabilize docs build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,27 @@
 name: Documentation
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/docs.yml"
+      - ".readthedocs.yaml"
+      - "docs/**"
+      - "src/**"
+      - "tools/update_api_reference.py"
+      - "pyproject.toml"
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/docs.yml"
+      - ".readthedocs.yaml"
+      - "docs/**"
+      - "src/**"
+      - "tools/update_api_reference.py"
+      - "pyproject.toml"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -18,14 +33,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            docs/requirements.txt
 
       - name: Install documentation dependencies
         run: |
@@ -33,20 +49,10 @@ jobs:
           python -m pip install -e .
           python -m pip install -r docs/requirements.txt
 
-      - name: Update API reference record
-        run: python tools/update_api_reference.py
+      - name: Verify API reference is current
+        run: |
+          python tools/update_api_reference.py
+          git diff --exit-code -- docs/API_Reference.rst
 
       - name: Build Read the Docs site
         run: sphinx-build -b html -W --keep-going docs docs/_build/html
-
-      - name: Commit API reference updates
-        run: |
-          if git diff --quiet -- docs/API_Reference.rst; then
-            echo "API reference is already current."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/API_Reference.rst
-          git commit -m "docs: update API reference"
-          git push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,19 +6,24 @@ on:
       - ".github/workflows/docs.yml"
       - ".readthedocs.yaml"
       - "docs/**"
+      - "images/**"
       - "src/**"
       - "tools/update_api_reference.py"
       - "pyproject.toml"
+      - "setup.py"
   push:
     branches:
       - main
+      - master
     paths:
       - ".github/workflows/docs.yml"
       - ".readthedocs.yaml"
       - "docs/**"
+      - "images/**"
       - "src/**"
       - "tools/update_api_reference.py"
       - "pyproject.toml"
+      - "setup.py"
 
 permissions:
   contents: read

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/API_Reference.rst
+++ b/docs/API_Reference.rst
@@ -358,6 +358,7 @@ buildcompiler.abstract_translator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: buildcompiler.abstract_translator
+   :no-index:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=7
+sphinx>=7,<9
 furo>=2024.1.29

--- a/tools/update_api_reference.py
+++ b/tools/update_api_reference.py
@@ -32,6 +32,7 @@ LEGACY_MODULES = {
 }
 
 EXCLUDED_MODULES = {"buildcompiler.__init__"}
+NO_INDEX_MODULES = {"buildcompiler.abstract_translator"}
 
 
 def underline(text: str, char: str = "=") -> str:
@@ -61,16 +62,21 @@ def modules_for_section(modules: list[str], package: str) -> list[str]:
 
 
 def render_module(name: str) -> list[str]:
-    return [
+    lines = [
         name,
         underline(name, "~"),
         "",
         f".. automodule:: {name}",
+    ]
+    if name in NO_INDEX_MODULES:
+        lines.append("   :no-index:")
+    lines.extend([
         "   :members:",
         "   :undoc-members:",
         "   :show-inheritance:",
         "",
-    ]
+    ])
+    return lines
 
 
 def render_api_reference() -> str:


### PR DESCRIPTION
### Motivation
- The docs deployment job was mutating and pushing `docs/API_Reference.rst` during the build which is brittle for protected branches and read-only CI tokens. 
- The workflow required repository write permissions and could silently succeed by committing generated artifacts instead of failing when checked-in artifacts are stale. 
- Read-the-Docs and GitHub Actions used different Python runtimes and an unbounded Sphinx requirement which made builds sensitive to environment drift and future Sphinx major releases.

### Description
- Update ` .github/workflows/docs.yml` to add a `pull_request` trigger for docs/source/config changes and to run the docs build on Python `3.11` with pip caching by setting `cache: pip` and `cache-dependency-path` to `pyproject.toml` and `docs/requirements.txt`.
- Change `permissions` in ` .github/workflows/docs.yml` from `contents: write` to `contents: read` and remove the CI step that committed/pushed `docs/API_Reference.rst`, replacing it with a deterministic freshness check `python tools/update_api_reference.py && git diff --exit-code -- docs/API_Reference.rst`.
- Align Read-the-Docs runtime by updating `.readthedocs.yaml` to use Python `3.11`.
- Pin Sphinx in `docs/requirements.txt` to `sphinx>=7,<9` to avoid unplanned breakage from future major Sphinx releases.

### Testing
- Ran `python tools/update_api_reference.py && git diff --exit-code -- docs/API_Reference.rst` and the freshness check succeeded.
- Ran `git diff --check` to validate there are no whitespace or diff issues and it succeeded. 
- Ran a small Python smoke-check that reads `.github/workflows/docs.yml` and `.readthedocs.yaml` to ensure the files are non-empty and readable and it succeeded. 
- Attempted local `pip install` and `sphinx-build` to reproduce the full build but the package index is unreachable in this environment (HTTP `403 Tunnel connection failed`) which caused install failures for build tools and Sphinx so the full Sphinx build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a551063f2808323ad981f32083ea998)